### PR TITLE
BAU: Fix SSH completion when not in the ida-ansible directory

### DIFF
--- a/ssh-complete.sh
+++ b/ssh-complete.sh
@@ -10,6 +10,7 @@ SEDPAT="$SEDPAT /^[^\.]*$/d;" # Remove lines not containing a dot (.)
 _complete-ssh () {
   local cur hostnames inventory
   inventory=$(awk -F= '/inventory/ {gsub(/ /, "", $2); gsub(/~/, "'$HOME'", $2); print $2}' "${IDA_ANSIBLE_DIR}/ansible.cfg")
+  [[ -e "$inventory" ]] || inventory="${IDA_ANSIBLE_DIR}/$inventory"
   cur=${COMP_WORDS[COMP_CWORD]}
 
   if [ -d $inventory ]; then

--- a/ssh-complete.zsh
+++ b/ssh-complete.zsh
@@ -13,6 +13,7 @@ _complete-ssh() {
       >&2 echo 'Error: IDA_ANSIBLE_DIR must be set'
   else
     inventory=$(awk -F= '/inventory/ {gsub(/ /, "", $2); gsub(/~/, "'$HOME'", $2); print $2}' "${IDA_ANSIBLE_DIR}/ansible.cfg")
+    [[ -e "$inventory" ]] || inventory="${IDA_ANSIBLE_DIR}/$inventory"
 
     if [ -d $inventory ]; then
       hostnames=$(sed "$SEDPAT" "${inventory}"* | sort -u | paste -s -)


### PR DESCRIPTION
If you weren't trying to complete hosts from the ansible directory, the hosts file would not be found and so generating the completions would fail. We now use an absolute path to avoid this.

Solo: @joerayme