### PR TITLE
TT-1029 : Migrate ida-ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Requirements
 ------------
 
 - jq (`brew install jq`)
-- ida-ansible repository checked out, and you need to have run the `hosts`
-  script in ida-ansible to generate a hosts cache file
+- verify-ansible repository checked out, and you need to have run the `hosts`
+  script in verify-ansible to generate a hosts cache file
 
 SSH Shell Completions
 ---------------------
@@ -25,7 +25,7 @@ follows.
 Add the following to your `~/.bashrc`, adjusting any paths as necessary.
 
 ```
-export IDA_ANSIBLE_DIR="${HOME}/Projects/ida-ansible"
+export VERIFY_ANSIBLE_DIR="${HOME}/Projects/verify-ansible"
 . ~/Projects/verify-shell-completions/ssh-complete.sh
 ```
 
@@ -34,7 +34,7 @@ export IDA_ANSIBLE_DIR="${HOME}/Projects/ida-ansible"
 Add the following to your `~/.zshrc`, adjusting paths as necessary.
 
 ```
-export IDA_ANSIBLE_DIR="${HOME}/Projects/ida-ansible"
+export VERIFY_ANSIBLE_DIR="${HOME}/Projects/verify-ansible"
 source ~/Projects/verify-shell-completions/ssh-complete.zsh
 
 ```
@@ -45,5 +45,5 @@ Usage
 Completions should now get the full list of hosts from the ansible inventory.
 
 To find out more about the dynamic inventory and how to refresh it see the
-[ida-ansible/README.md](https://github.digital.cabinet-office.gov.uk/gds/ida-ansible/tree/master#dynamic-inventory)
+[verify-ansible/README.md](https://github.com/alphagov/verify-ansible/tree/master#dynamic-inventory)
 

--- a/ssh-complete.sh
+++ b/ssh-complete.sh
@@ -9,7 +9,7 @@ SEDPAT="$SEDPAT /^[^\.]*$/d;" # Remove lines not containing a dot (.)
 
 _complete-ssh () {
   local cur hostnames inventory
-  inventory=$(awk -F= '/inventory/ {gsub(/ /, "", $2); gsub(/~/, "'$HOME'", $2); print $2}' "${IDA_ANSIBLE_DIR}/ansible.cfg")
+  inventory=$(awk -F= '/inventory/ {gsub(/ /, "", $2); gsub(/~/, "'$HOME'", $2); print $2}' "${VERIFY_ANSIBLE_DIR}/ansible.cfg")
   cur=${COMP_WORDS[COMP_CWORD]}
 
   if [ -d $inventory ]; then
@@ -23,15 +23,15 @@ _complete-ssh () {
 
   else
     >&2 echo
-    >&2 echo "Could not find inventory file $inventory. Make sure $IDA_ANSIBLE_DIR/ansible.cfg has an absolute path to its hosts file."
+    >&2 echo "Could not find inventory file $inventory. Make sure $VERIFY_ANSIBLE_DIR/ansible.cfg has an absolute path to its hosts file."
   fi
 
   COMPREPLY=( $( compgen -W  "$hostnames" -- "$cur" ) )
 }
 
-if [ -z "$IDA_ANSIBLE_DIR" ]
+if [ -z "$VERIFY_ANSIBLE_DIR" ]
 then
-  >&2 echo 'Error: IDA_ANSIBLE_DIR must be set'
+  >&2 echo 'Error: VERIFY_ANSIBLE_DIR must be set'
 else
   complete -F _complete-ssh ssh
 fi

--- a/ssh-complete.zsh
+++ b/ssh-complete.zsh
@@ -8,11 +8,11 @@ SEDPAT="$SEDPAT /^[^\.]*$/d;" # Remove lines not containing a dot (.)
 _complete-ssh() {
   local hostnames inventory
 
-  if [ -z "$IDA_ANSIBLE_DIR" ]
+  if [ -z "$VERIFY_ANSIBLE_DIR" ]
   then
-      >&2 echo 'Error: IDA_ANSIBLE_DIR must be set'
+      >&2 echo 'Error: VERIFY_ANSIBLE_DIR must be set'
   else
-    inventory=$(awk -F= '/inventory/ {gsub(/ /, "", $2); gsub(/~/, "'$HOME'", $2); print $2}' "${IDA_ANSIBLE_DIR}/ansible.cfg")
+    inventory=$(awk -F= '/inventory/ {gsub(/ /, "", $2); gsub(/~/, "'$HOME'", $2); print $2}' "${VERIFY_ANSIBLE_DIR}/ansible.cfg")
 
     if [ -d $inventory ]; then
       hostnames=$(sed "$SEDPAT" "${inventory}"* | sort -u | paste -s -)


### PR DESCRIPTION
ida-ansible is moving to verify-ansible on Github.com.  This commit
adjusts file paths and documentation for integrating the shell with the
config.

The team will need to update their shell config and this repo to get the
latest changes.

Solo: @brandenfaulls